### PR TITLE
Superball handle fix (completely smooth)

### DIFF
--- a/Tools/Superball/Handle.model.json
+++ b/Tools/Superball/Handle.model.json
@@ -6,11 +6,13 @@
 		"Color": [0.768628, 0.156863, 0.109804],
 		"Reflectance": 0.2,
 		
-		"Material": "SmoothPlastic",
-		
 		"Shape": "Ball",
 		
-		"Size": [2, 2, 2]
+		"Size": [2, 2, 2],
+
+		"TopSurface": "Smooth",
+		
+		"BottomSurface": "Smooth"
 	},
 	
 	"Children":


### PR DESCRIPTION
Removed the material property (since smooth plastic isn't supported in the engine). Should default to (normal) plastic material.

Specified the top and bottom surfaces should be smooth. Since normal plastic shows surface textures, the superball has to be completely smooth to appear as it did around '07.

Hope this works :P.